### PR TITLE
support show only one interface

### DIFF
--- a/assets/requests/resp.show.interface.mgmt0.json
+++ b/assets/requests/resp.show.interface.mgmt0.json
@@ -1,0 +1,46 @@
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "body": {
+      "TABLE_interface": {
+        "ROW_interface": {
+          "interface": "mgmt0",
+          "state": "up",
+          "eth_hw_desc": "GigabitEthernet",
+          "eth_hw_addr": "b026.809b.4540",
+          "eth_bia_addr": "b026.809b.4540",
+          "eth_ip_addr": "10.8.6.35",
+          "eth_ip_mask": 16,
+          "eth_ip_prefix": "10.8.0.0",
+          "eth_mtu": "1500",
+          "eth_bw": 1000000,
+          "eth_dly": 10,
+          "eth_reliability": "255",
+          "eth_txload": "1",
+          "eth_rxload": "1",
+          "encapsulation": "ARPA",
+          "eth_duplex": "full",
+          "eth_speed": "1000 Mb/s",
+          "eth_autoneg": "on",
+          "eth_mdix": "off",
+          "eth_ethertype": "0x0000",
+          "vdc_lvl_in_avg_bits": 6824,
+          "vdc_lvl_in_avg_pkts": "8",
+          "vdc_lvl_out_avg_bits": "320",
+          "vdc_lvl_out_avg_pkts": "0",
+          "vdc_lvl_in_pkts": 160834516,
+          "vdc_lvl_in_ucast": "737253",
+          "vdc_lvl_in_mcast": "22050167",
+          "vdc_lvl_in_bcast": "138047096",
+          "vdc_lvl_in_bytes": "11278664305",
+          "vdc_lvl_out_pkts": "464706",
+          "vdc_lvl_out_ucast": "406913",
+          "vdc_lvl_out_mcast": "57775",
+          "vdc_lvl_out_bcast": "18",
+          "vdc_lvl_out_bytes": "63101650"
+        }
+      }
+    }
+  },
+  "id": 1
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -174,6 +174,25 @@ func main() {
 		}
 	default:
 		start := time.Now()
+
+		if strings.HasPrefix(cliCommand, "show interface") {
+			intfName := cliCommand[len("show interface "):]
+			intfInfo, err := cli.GetInterface(intfName)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+			var out strings.Builder
+			out.WriteString(fmt.Sprintf("State: %s/%s", intfInfo.Props.State, intfInfo.Props.AdminState))
+			if intfInfo.Props.BiaHwAddr != "" {
+				out.WriteString(fmt.Sprintf(", MAC: %s", intfInfo.Props.BiaHwAddr))
+			}
+			if intfInfo.Props.IPAddress != "" {
+				out.WriteString(fmt.Sprintf(", IP: %s/%d", intfInfo.Props.IPAddress, intfInfo.Props.IPMask))
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", out.String())
+			return
+		}
+
 		output, err := cli.GetGeneric(cliCommand)
 		if err != nil {
 			log.Fatalf("%s", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -296,6 +296,24 @@ func (cli *Client) GetInterfaces() ([]*Interface, error) {
 	return NewInterfacesFromBytes(resp)
 }
 
+// GetInterface returns interface information ("show interface <name>").
+func (cli *Client) GetInterface(name string) (*Interface, error) {
+	url := fmt.Sprintf("%s://%s:%d/ins", cli.protocol, cli.host, cli.port)
+	req := NewJSONRPCRequest([]string{"show interface " + name})
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := callAPI("jsonrpc", url, payload, cli.username, cli.password, cli.secure)
+	if err != nil {
+		return nil, err
+	}
+
+	intf, err := NewInterfaceFromBytes(resp)
+
+	return intf, err
+}
+
 // GetSystemResources returns SystemResources instance ("show system resources").
 func (cli *Client) GetSystemResources() (*SystemResources, error) {
 	url := fmt.Sprintf("%s://%s:%d/ins", cli.protocol, cli.host, cli.port)

--- a/pkg/client/interface_test.go
+++ b/pkg/client/interface_test.go
@@ -93,6 +93,17 @@ func TestParseShowInterfaceJsonOutput(t *testing.T) {
 	if testFailed > 0 {
 		t.Fatalf("Failed %d tests", testFailed)
 	}
+
+	// parse show single interface
+	fp := fmt.Sprintf("%s/resp.%s.json", outputDir, "show.interface.mgmt0")
+	content, err := ioutil.ReadFile(fp)
+	if err != nil {
+		t.Fatalf("FAIL: Test failed reading '%s', error: %v", fp, err)
+	}
+	_, err = NewInterfaceFromBytes(content)
+	if err != nil {
+		t.Fatalf("FAIL: Test failed reading '%s', error: %v", fp, err)
+	}
 }
 
 func TestParseShowInterfaceEthernet(t *testing.T) {


### PR DESCRIPTION
change interface code to use common JSON response format.
support show only one interface - sometimes we only need to know one interface information.