### PR TITLE
add api to show running configuration per interface

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -18,12 +18,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	//"github.com/davecgh/go-spew/spew"
-	"github.com/greenpau/go-cisco-nx-api/pkg/client"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"time"
+
+	//"github.com/davecgh/go-spew/spew"
+	"github.com/greenpau/go-cisco-nx-api/pkg/client"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -191,6 +192,17 @@ func main() {
 				out.WriteString(fmt.Sprintf(", IP: %s/%d", intfInfo.Props.IPAddress, intfInfo.Props.IPMask))
 			}
 			fmt.Fprintf(os.Stdout, "%s\n", out.String())
+			return
+		}
+
+		// show running-config interface <name>
+		if strings.HasPrefix(cliCommand, "show running-config interface") {
+			intfName := cliCommand[len("show running-config interface "):]
+			intfInfo, err := cli.GetInterfaceRunningConfiguration(intfName)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", intfInfo.Text)
 			return
 		}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -380,18 +380,25 @@ func (cli *Client) GetBgpSummary() (*BgpSummary, error) {
 // GetRunningConfiguration returns Configuration instance for running
 // configuration ("show running-config").
 func (cli *Client) GetRunningConfiguration() (*Configuration, error) {
-	return cli.getConfiguration("running")
+	return cli.getConfiguration("running-config")
+}
+
+// GetInterfaceRunningConfiguration returns Configuration instance for
+// specific port's running configuration ("show running-config interface").
+func (cli *Client) GetInterfaceRunningConfiguration(intf string) (*Configuration,
+	error) {
+	return cli.getConfiguration("running-config interface " + intf)
 }
 
 // GetStartupConfiguration returns Configuration instance for startup
 // configuration ("show startup-config").
 func (cli *Client) GetStartupConfiguration() (*Configuration, error) {
-	return cli.getConfiguration("startup")
+	return cli.getConfiguration("startup-config")
 }
 
 func (cli *Client) getConfiguration(s string) (*Configuration, error) {
 	url := fmt.Sprintf("%s://%s:%d/ins", cli.protocol, cli.host, cli.port)
-	req := NewInsAPICliShowASCIIRequest("show " + s + "-config")
+	req := NewInsAPICliShowASCIIRequest("show " + s)
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
UT has done:
```
$ ./client -cli "show running-config interface ethernet 1/39"

!Command: show running-config interface Ethernet1/39
!Running configuration last done at: Thu Nov  1 02:10:28 2001
!Time: Thu Nov  1 02:57:34 2001

version 9.2(2) Bios:version 5.2.0

interface Ethernet1/39
  switchport access vlan 114
    spanning-tree port type edge trunk
```

UT is good for changed running-config and startup-config function too

Signed-off-by: Leslie Qi Wang <qiwa@pensando.io>